### PR TITLE
[Feature] Add useful extensions for `CIImage.properties`

### DIFF
--- a/Sources/SwiftyImageIO/Extensions/CoreImage/CIImage+Properties.swift
+++ b/Sources/SwiftyImageIO/Extensions/CoreImage/CIImage+Properties.swift
@@ -1,0 +1,13 @@
+//
+//  CIImage+Properties.swift
+//
+//  
+//  Created by TakashiUshikoshi on 2023/06/30
+//  
+//
+
+import CoreImage
+
+public extension CIImage {
+    typealias Properties = ImageIOProperties
+}

--- a/Sources/SwiftyImageIO/Extensions/CoreImage/CIImage+SettingProperties.swift
+++ b/Sources/SwiftyImageIO/Extensions/CoreImage/CIImage+SettingProperties.swift
@@ -1,0 +1,24 @@
+//
+//  CIImage+.swift
+//
+//  
+//  Created by TakashiUshikoshi on 2023/06/30
+//  
+//
+
+import CoreImage
+import DictionaryCoder
+import Foundation
+
+public extension CIImage {
+    /// Returns a new image created by adding the specified metadata properties to the image.
+    /// - Parameter properties: The metadata properties to associate with the image.
+    /// - Returns: An image object with the specified properties.
+    func settingProperties(_ properties: CIImage.Properties) throws -> CIImage {
+        let dictionaryEncodedProperties = try DictionaryEncoder.swiftyPropertiesEncoder.encode(properties)
+
+        let propertiesModifiedImage: CIImage = self.settingProperties(dictionaryEncodedProperties)
+
+        return propertiesModifiedImage
+    }
+}

--- a/Sources/SwiftyImageIO/Extensions/CoreImage/CIImage+SwiftyImageProperties.swift
+++ b/Sources/SwiftyImageIO/Extensions/CoreImage/CIImage+SwiftyImageProperties.swift
@@ -1,0 +1,28 @@
+//
+//  CIImage+SwiftyImageProperties.swift
+//
+//  
+//  Created by TakashiUshikoshi on 2023/06/30
+//  
+//
+
+import CoreImage
+import DictionaryCoder
+
+public extension CIImage {
+    /// A decoded struct containing metadata about the image.
+    /// 
+    /// It returns `nil` if the decoding of [properties](https://developer.apple.com/documentation/coreimage/ciimage/1437733-properties) fails.
+    var swiftyImageProperties: CIImage.Properties? {
+        let dictionaryDecoder: DictionaryDecoder = .init()
+        
+        dictionaryDecoder.dateDecodingStrategy = .formatted(.tiff)
+        
+        let decodedProperties: CIImage.Properties? = try? dictionaryDecoder.decode(
+            CIImage.Properties.self,
+            from: self.properties
+        )
+        
+        return decodedProperties
+    }
+}

--- a/Sources/SwiftyImageIO/Extensions/DictionaryCoder/DictionaryDecoder+ImagePropertiesDecoder.swift
+++ b/Sources/SwiftyImageIO/Extensions/DictionaryCoder/DictionaryDecoder+ImagePropertiesDecoder.swift
@@ -1,0 +1,19 @@
+//
+//  DictionaryDecoder+ImagePropertiesDecoder.swift
+//
+//  
+//  Created by TakashiUshikoshi on 2023/07/01
+//  
+//
+
+import DictionaryCoder
+
+extension DictionaryDecoder {
+    static var imagePropertiesDecoder: DictionaryDecoder {
+        let decoder: DictionaryDecoder = .init()
+
+        decoder.dateDecodingStrategy = .formatted(.tiff)
+
+        return decoder
+    }
+}

--- a/Sources/SwiftyImageIO/Extensions/DictionaryCoder/DictionaryEncoder+SwiftyPropertiesEncoder.swift
+++ b/Sources/SwiftyImageIO/Extensions/DictionaryCoder/DictionaryEncoder+SwiftyPropertiesEncoder.swift
@@ -1,0 +1,19 @@
+//
+//  DictionaryEncoder+SwiftyPropertiesEncoder.swift
+//
+//  
+//  Created by TakashiUshikoshi on 2023/07/01
+//  
+//
+
+import DictionaryCoder
+
+extension DictionaryEncoder {
+    static var swiftyPropertiesEncoder: DictionaryEncoder {
+        let dictionaryEncoder: DictionaryEncoder = .init()
+        
+        dictionaryEncoder.dateEncodingStrategy = .formatted(.tiff)
+        
+        return dictionaryEncoder
+    }
+}


### PR DESCRIPTION
## Summary

This pull request adds some useful extensions for CIImage.

- `CIImage.Properties` typealias for simplifying type annotations.
- `settingProperties(:)` function to generate a new CIImage that `properties` modified
- Decoded `CIImage.properties` named `swiftyImageProperties`